### PR TITLE
Make event title dynamic

### DIFF
--- a/resources/views/day.blade.php
+++ b/resources/views/day.blade.php
@@ -25,7 +25,7 @@
                 </p>
                 <p class="text-xs text-gray-600 ml-4">
                     @if($events->isNotEmpty())
-                        {{ $events->count() }} {{ Str::plural('event', $events->count()) }}
+                        {{ $events->count() }} {{ Str::plural($eventTitle, $events->count()) }}
                     @endif
                 </p>
             </div>

--- a/src/LivewireCalendar.php
+++ b/src/LivewireCalendar.php
@@ -21,6 +21,7 @@ use Livewire\Component;
  * @property string $calendarView
  * @property string $dayView
  * @property string $eventView
+ * @property string $eventTitle
  * @property string $dayOfWeekView
  * @property string $beforeCalendarWeekView
  * @property string $afterCalendarWeekView
@@ -33,6 +34,8 @@ use Livewire\Component;
  */
 class LivewireCalendar extends Component
 {
+    public $eventTitle="Events";
+
     public $startsAt;
     public $endsAt;
 

--- a/src/LivewireCalendar.php
+++ b/src/LivewireCalendar.php
@@ -34,7 +34,7 @@ use Livewire\Component;
  */
 class LivewireCalendar extends Component
 {
-    public $eventTitle="Events";
+    public $eventTitle="Event";
 
     public $startsAt;
     public $endsAt;


### PR DESCRIPTION
I have just made the word event on Calendar dynamic. To overwrite it in your system,  you have just to create a public variable called $eventTitle.

eg: public $eventTitle = 'Rota';

or public $eventTitle;

public function mount() {
   $eventTitle = 'rota';
}


NOTE: Feel free to close it.

Thank you