### PR TITLE
Add directive in boot()

### DIFF
--- a/src/LivewireCalendarServiceProvider.php
+++ b/src/LivewireCalendarServiceProvider.php
@@ -19,13 +19,7 @@ class LivewireCalendarServiceProvider extends ServiceProvider
                 __DIR__.'/../resources/views' => $this->app->resourcePath('views/vendor/livewire-calendar'),
             ], 'livewire-calendar');
         }
-    }
 
-    /**
-     * Register the application services.
-     */
-    public function register()
-    {
         Blade::directive('livewireCalendarScripts', function () {
             return <<<'HTML'
             <script>


### PR DESCRIPTION
Similar to https://github.com/asantibanez/livewire-resource-time-grid/pull/4
The Blade direct should be in the boot() method, to guarantee correct order of dependencies. Otherwise this will result in an error with the default Jetstream install:

> Livewire\Exceptions\ComponentNotFoundException
> Unable to find component: [navigation-dropdown]