### PR TITLE
An implementation for events that span multiple days.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.0 - 2021-05-12
+
+- Added support for multi day events
+
 ## 2.1.0 - 2021-01-25
 
 - Added support for PHP 8

--- a/README.md
+++ b/README.md
@@ -107,6 +107,25 @@ public function events(): Collection
 }
 ```
 
+Events can be marked as multiday events by giving them an `end` and `multiday` attributes
+
+Example
+```php
+public function events() : Collection
+{
+    return collect([
+        [
+            'id' => 1,
+            'title' => 'Holiday',
+            'description' => 'Off To The Beach!',
+            'date' => Carbon::today(),
+            'end' => Carbon::today()->addDays(4),
+            'mulitday' => true,
+        ],
+    ]);
+}
+```
+
 Now, we can include our component in any view. 
 
 Example

--- a/resources/views/event.blade.php
+++ b/resources/views/event.blade.php
@@ -7,6 +7,11 @@
     <p class="text-sm font-medium">
         {{ $event['title'] }}
     </p>
+    <p class="mt-0 text-xs">
+        @if(!isset($event['multiday']) || $event['multiday']!== true)
+            {{$event['date']->format('G:i')}} - {{$event['end']->format('G:i')}}
+        @endif
+    </p>
     <p class="mt-2 text-xs">
         {{ $event['description'] ?? 'No description' }}
     </p>

--- a/src/LivewireCalendar.php
+++ b/src/LivewireCalendar.php
@@ -205,10 +205,15 @@ class LivewireCalendar extends Component
 
     public function getEventsForDay($day, Collection $events) : Collection
     {
-        return $events
-            ->filter(function ($event) use ($day) {
-                return Carbon::parse($event['date'])->isSameDay($day);
-            });
+        return $events->filter(function ($event) use ($day)
+        {
+            if(isset($event['multiday']) && $event['multiday']===true)
+            {
+                return $day->between(Carbon::parse($event['date']), Carbon::parse($event['end']));
+            }
+
+            return Carbon::parse($event['date'])->isSameDay($day);
+        });
     }
 
     public function onDayClick($year, $month, $day)


### PR DESCRIPTION
This uses a bool called multiday on the event.
If the event is not a multi day event, event.blade.php now shows the start and end times.