### PR TITLE
Added ability to toggle rendering weekends

### DIFF
--- a/resources/views/calendar.blade.php
+++ b/resources/views/calendar.blade.php
@@ -15,20 +15,24 @@
 
                 <div class="w-full flex flex-row">
                     @foreach($monthGrid->first() as $day)
-                        @include($dayOfWeekView, ['day' => $day])
+                        @unless($hideWeekends && $day->isWeekend())
+                            @include($dayOfWeekView, ['day' => $day])
+                        @endunless
                     @endforeach
                 </div>
 
                 @foreach($monthGrid as $week)
                     <div class="w-full flex flex-row">
                         @foreach($week as $day)
-                            @include($dayView, [
-                                    'componentId' => $componentId,
-                                    'day' => $day,
-                                    'dayInMonth' => $day->isSameMonth($startsAt),
-                                    'isToday' => $day->isToday(),
-                                    'events' => $getEventsForDay($day, $events),
-                                ])
+                            @unless($hideWeekends && $day->isWeekend())
+                                @include($dayView, [
+                                        'componentId' => $componentId,
+                                        'day' => $day,
+                                        'dayInMonth' => $day->isSameMonth($startsAt),
+                                        'isToday' => $day->isToday(),
+                                        'events' => $getEventsForDay($day, $events),
+                                    ])
+                            @endunless
                         @endforeach
                     </div>
                 @endforeach

--- a/src/LivewireCalendar.php
+++ b/src/LivewireCalendar.php
@@ -30,6 +30,7 @@ use Livewire\Component;
  * @property boolean $dragAndDropEnabled
  * @property boolean $dayClickEnabled
  * @property boolean $eventClickEnabled
+ * @property boolean $hideWeekends
  */
 class LivewireCalendar extends Component
 {
@@ -59,6 +60,8 @@ class LivewireCalendar extends Component
     public $dayClickEnabled;
     public $eventClickEnabled;
 
+    public $hideWeekends;
+
     protected $casts = [
         'startsAt' => 'date',
         'endsAt' => 'date',
@@ -81,6 +84,7 @@ class LivewireCalendar extends Component
                           $dragAndDropEnabled = true,
                           $dayClickEnabled = true,
                           $eventClickEnabled = true,
+                          $hideWeekends = false,
                           $extras = [])
     {
         $this->weekStartsAt = $weekStartsAt ?? Carbon::SUNDAY;
@@ -106,6 +110,8 @@ class LivewireCalendar extends Component
 
         $this->dayClickEnabled = $dayClickEnabled;
         $this->eventClickEnabled = $eventClickEnabled;
+
+        $this->hideWeekends = $hideWeekends;
 
         $this->afterMount($extras);
     }
@@ -159,6 +165,11 @@ class LivewireCalendar extends Component
         $this->endsAt = $this->startsAt->clone()->endOfMonth()->startOfDay();
 
         $this->calculateGridStartsEnds();
+    }
+
+    public function toggleWeekends()
+    {
+        $this->hideWeekends = !$this->hideWeekends;
     }
 
     public function calculateGridStartsEnds()


### PR DESCRIPTION
This uses a bool called hideWeekends on the calendar.blade.php, if it is set to true and the day is a weekend, it will skip rendering the day.

May contain a breaking change for anyone who is overwriting LivewireCalendar::mount(). However, they should be using LivewireCalendar::afterMount() anyway.
