### PR TITLE
Allow illuminate/support v9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
         "livewire/livewire": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Updated composer.json to allow `illuminate/support` v9