### PR TITLE
Fixed navigating to a longer next/previous month

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
         "livewire/livewire": "^2.0"
     },
     "require-dev": {

--- a/src/LivewireCalendar.php
+++ b/src/LivewireCalendar.php
@@ -139,16 +139,16 @@ class LivewireCalendar extends Component
 
     public function goToPreviousMonth()
     {
-        $this->startsAt->subMonthNoOverflow();
-        $this->endsAt->subMonthNoOverflow();
+        $this->startsAt->subMonthNoOverflow()->startOfMonth()->startOfDay();
+        $this->endsAt->subMonthNoOverflow()->endOfMonth()->startOfDay();
 
         $this->calculateGridStartsEnds();
     }
 
     public function goToNextMonth()
     {
-        $this->startsAt->addMonthNoOverflow();
-        $this->endsAt->addMonthNoOverflow();
+        $this->startsAt->addMonthNoOverflow()->startOfMonth()->startOfDay();
+        $this->endsAt->addMonthNoOverflow()->endOfMonth()->startOfDay();
 
         $this->calculateGridStartsEnds();
     }

--- a/tests/LivewireCalendarTest.php
+++ b/tests/LivewireCalendarTest.php
@@ -3,6 +3,7 @@
 namespace Asantibanez\LivewireCalendar\Tests;
 
 use Asantibanez\LivewireCalendar\LivewireCalendar;
+use Carbon\Carbon;
 use Livewire\LivewireManager;
 use Livewire\Testing\TestableLivewire;
 
@@ -91,4 +92,49 @@ class LivewireCalendarTest extends TestCase
             $component->get('endsAt')
         );
     }
+
+    /** @test */
+    public function can_navigate_to_a_previous_longer_month()
+    {
+        //Arrange
+        Carbon::setTestNow('first Monday of February 2023');
+        $component = $this->createComponent([]);
+
+        //Act
+        $component->runAction('goToPreviousMonth');
+
+        //Assert
+        $this->assertEquals(
+            today()->subMonth()->startOfMonth()->startOfDay(),
+            $component->get('startsAt')
+        );
+
+        $this->assertEquals(
+            today()->subMonth()->endOfMonth()->startOfDay(),
+            $component->get('endsAt')
+        );
+    }
+
+    /** @test */
+    public function can_navigate_to_a_next_longer_month()
+    {
+        //Arrange
+        Carbon::setTestNow('first Monday of April 2023');
+        $component = $this->createComponent([]);
+
+        //Act
+        $component->runAction('goToNextMonth');
+
+        //Assert
+        $this->assertEquals(
+            today()->addMonth()->startOfMonth()->startOfDay(),
+            $component->get('startsAt')
+        );
+
+        $this->assertEquals(
+            today()->addMonth()->endOfMonth()->startOfDay(),
+            $component->get('endsAt')
+        );
+    }
+
 }


### PR DESCRIPTION
- When the calendar loads in a month that is short, say February, the endsAt is set as the 28th (unless it's a leap year)
- When you hit `goToPreviousMonth` to go to January, the package is doing $this->endsAt->subMonthNoOverflow() which is keeping the end date for January as 28th
- This makes the grid not load the final week

Added tests to illustrate the scenario.